### PR TITLE
feat: TTL-based eviction for RateLimiter (issue #6)

### DIFF
--- a/internal/security/ratelimit.go
+++ b/internal/security/ratelimit.go
@@ -7,20 +7,34 @@ import (
 	"golang.org/x/time/rate"
 )
 
-// RateLimiter is a per-client token-bucket rate limiter.
+type entry struct {
+	limiter  *rate.Limiter
+	lastSeen time.Time
+}
+
+// RateLimiter is a per-client token-bucket rate limiter with optional TTL-based eviction.
 type RateLimiter struct {
-	mu       sync.Mutex
-	limiters map[string]*rate.Limiter
-	rpm      int
-	burst    int
+	mu      sync.Mutex
+	entries map[string]*entry
+	rpm     int
+	burst   int
+	ttl     time.Duration
 }
 
 // NewRateLimiter creates a RateLimiter with the given requests-per-minute and burst size.
+// Entries are never evicted unless Evict is called explicitly or a background ticker calls it.
 func NewRateLimiter(rpm, burst int) *RateLimiter {
+	return NewRateLimiterWithTTL(rpm, burst, 0)
+}
+
+// NewRateLimiterWithTTL creates a RateLimiter that considers entries older than ttl as
+// evictable. Set ttl = 0 to disable eviction.
+func NewRateLimiterWithTTL(rpm, burst int, ttl time.Duration) *RateLimiter {
 	return &RateLimiter{
-		limiters: make(map[string]*rate.Limiter),
-		rpm:      rpm,
-		burst:    burst,
+		entries: make(map[string]*entry),
+		rpm:     rpm,
+		burst:   burst,
+		ttl:     ttl,
 	}
 }
 
@@ -31,11 +45,37 @@ func (rl *RateLimiter) Allow(clientID string) bool {
 		return true
 	}
 	rl.mu.Lock()
-	lim, ok := rl.limiters[clientID]
+	e, ok := rl.entries[clientID]
 	if !ok {
-		lim = rate.NewLimiter(rate.Every(time.Minute/time.Duration(rl.rpm)), rl.burst)
-		rl.limiters[clientID] = lim
+		e = &entry{
+			limiter: rate.NewLimiter(rate.Every(time.Minute/time.Duration(rl.rpm)), rl.burst),
+		}
+		rl.entries[clientID] = e
 	}
+	e.lastSeen = time.Now()
 	rl.mu.Unlock()
-	return lim.Allow()
+	return e.limiter.Allow()
+}
+
+// Evict removes entries that have not been seen for longer than the configured TTL.
+// No-op when TTL is zero.
+func (rl *RateLimiter) Evict() {
+	if rl.ttl <= 0 {
+		return
+	}
+	cutoff := time.Now().Add(-rl.ttl)
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	for id, e := range rl.entries {
+		if e.lastSeen.Before(cutoff) {
+			delete(rl.entries, id)
+		}
+	}
+}
+
+// Len returns the current number of tracked client entries.
+func (rl *RateLimiter) Len() int {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	return len(rl.entries)
 }

--- a/internal/security/ratelimit_test.go
+++ b/internal/security/ratelimit_test.go
@@ -2,6 +2,7 @@ package security_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -33,4 +34,47 @@ func TestRateLimiter_Disabled(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		require.True(t, rl.Allow("client-1"))
 	}
+}
+
+func TestRateLimiter_EvictsIdleEntries(t *testing.T) {
+	ttl := 50 * time.Millisecond
+	rl := security.NewRateLimiterWithTTL(10, 1, ttl)
+	require.True(t, rl.Allow("client-1"))
+	require.False(t, rl.Allow("client-1")) // burst exhausted
+
+	time.Sleep(ttl * 3)
+	rl.Evict() // explicit sweep
+
+	// After eviction the entry is gone; a fresh limiter is created with full burst.
+	require.True(t, rl.Allow("client-1"))
+}
+
+func TestRateLimiter_LenAfterEviction(t *testing.T) {
+	ttl := 50 * time.Millisecond
+	rl := security.NewRateLimiterWithTTL(10, 1, ttl)
+	rl.Allow("a")
+	rl.Allow("b")
+	rl.Allow("c")
+	require.Equal(t, 3, rl.Len())
+
+	time.Sleep(ttl * 3)
+	rl.Evict()
+	require.Equal(t, 0, rl.Len())
+}
+
+func TestRateLimiter_ActiveEntryNotEvicted(t *testing.T) {
+	ttl := 100 * time.Millisecond
+	rl := security.NewRateLimiterWithTTL(60, 5, ttl)
+	rl.Allow("active")
+	rl.Allow("idle")
+
+	// Refresh "active" at ttl/2 so it stays well within TTL.
+	time.Sleep(ttl / 2)
+	rl.Allow("active")
+
+	// Sleep only ttl/2 more: "idle" is now ttl*1.5 old (expired), "active" is ttl/2 old (fresh).
+	time.Sleep(ttl / 2)
+	rl.Evict()
+
+	require.Equal(t, 1, rl.Len()) // only "active" remains
 }


### PR DESCRIPTION
## Summary
- Adds `NewRateLimiterWithTTL(rate, burst, ttl)` constructor
- Adds `Evict()` method that removes limiter entries idle longer than `ttl`
- Adds `Len()` for observability and test assertions
- Zero-TTL path is unchanged — no breaking changes

## Test plan
- [ ] `TestRateLimiter_EvictsIdleEntries` — entries past TTL are removed
- [ ] `TestRateLimiter_LenAfterEviction` — `Len()` reflects post-eviction count
- [ ] `TestRateLimiter_ActiveEntryNotEvicted` — recently-used entries survive eviction
- [ ] All existing rate-limiter tests still pass

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)