### PR TITLE
feat: codebook Compile — prose-in token abbreviation map

### DIFF
--- a/internal/identity/codebook/compile.go
+++ b/internal/identity/codebook/compile.go
@@ -1,0 +1,71 @@
+package codebook
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Compile scans prose for high-frequency multi-syllable tokens (len > 6, freq > 1)
+// and returns a substitution map of original_token → short_abbreviation.
+// The abbreviations are unique within the returned map.
+func Compile(text string) (map[string]string, error) {
+	if text == "" {
+		return map[string]string{}, nil
+	}
+
+	// Count normalized (lowercased) token frequencies.
+	freq := make(map[string]int)
+	for _, tok := range strings.Fields(text) {
+		tok = strings.ToLower(strings.Trim(tok, ".,;:!?\"'()[]{}"))
+		if len(tok) > 6 {
+			freq[tok]++
+		}
+	}
+
+	// Collect candidates: tokens that appear more than once.
+	var candidates []string
+	for tok, count := range freq {
+		if count > 1 {
+			candidates = append(candidates, tok)
+		}
+	}
+
+	if len(candidates) == 0 {
+		return map[string]string{}, nil
+	}
+
+	result := make(map[string]string, len(candidates))
+	usedAbbrs := make(map[string]struct{})
+
+	for _, tok := range candidates {
+		abbr, err := uniqueAbbreviation(tok, usedAbbrs)
+		if err != nil {
+			return nil, err
+		}
+		result[tok] = abbr
+		usedAbbrs[abbr] = struct{}{}
+	}
+
+	return result, nil
+}
+
+// uniqueAbbreviation generates a short abbreviation for tok that does not collide
+// with already-used abbreviations. It tries increasing prefix lengths starting at 3.
+func uniqueAbbreviation(tok string, used map[string]struct{}) (string, error) {
+	runes := []rune(tok)
+	for length := 3; length < len(runes); length++ {
+		candidate := string(runes[:length])
+		if _, taken := used[candidate]; !taken {
+			return candidate, nil
+		}
+	}
+	// Fall back: append a numeric suffix to a 3-char prefix.
+	base := string(runes[:3])
+	for i := 2; i <= len(runes); i++ {
+		candidate := fmt.Sprintf("%s%d", base, i)
+		if _, taken := used[candidate]; !taken {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("could not generate unique abbreviation for %q", tok)
+}

--- a/internal/identity/codebook/compile_test.go
+++ b/internal/identity/codebook/compile_test.go
@@ -1,0 +1,68 @@
+package codebook_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/pythondatascrape/engram/internal/identity/codebook"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompile_ExtractsHighFrequencyTokens(t *testing.T) {
+	prompt := "authentication authentication authentication configuration configuration configuration"
+	subs, err := codebook.Compile(prompt)
+	require.NoError(t, err)
+	assert.Contains(t, subs, "authentication")
+	assert.Contains(t, subs, "configuration")
+	// abbreviations must be shorter than original
+	for orig, abbr := range subs {
+		assert.Less(t, len(abbr), len(orig))
+	}
+}
+
+func TestCompile_IgnoresShortTokens(t *testing.T) {
+	// tokens <=6 chars should never appear in the result
+	prompt := "go go go go go run run run run run"
+	subs, err := codebook.Compile(prompt)
+	require.NoError(t, err)
+	for orig := range subs {
+		assert.Greater(t, len(orig), 6, "unexpected short token %q in substitution map", orig)
+	}
+}
+
+func TestCompile_IgnoresRareTokens(t *testing.T) {
+	// a long token that only appears once should not be abbreviated
+	prompt := "authentication authentication authentication uniquetoken"
+	subs, err := codebook.Compile(prompt)
+	require.NoError(t, err)
+	assert.NotContains(t, subs, "uniquetoken")
+}
+
+func TestCompile_AbbreviationsAreUnique(t *testing.T) {
+	prompt := strings.Repeat("authentication configuration authorization ", 5)
+	subs, err := codebook.Compile(prompt)
+	require.NoError(t, err)
+	seen := make(map[string]string)
+	for orig, abbr := range subs {
+		if prev, exists := seen[abbr]; exists {
+			t.Errorf("abbreviation %q used for both %q and %q", abbr, prev, orig)
+		}
+		seen[abbr] = orig
+	}
+}
+
+func TestCompile_EmptyInput(t *testing.T) {
+	subs, err := codebook.Compile("")
+	require.NoError(t, err)
+	assert.Empty(t, subs)
+}
+
+func TestCompile_NormalizesCase(t *testing.T) {
+	// tokens are lowercased before counting
+	prompt := "Authentication authentication AUTHENTICATION configuration configuration configuration"
+	subs, err := codebook.Compile(prompt)
+	require.NoError(t, err)
+	// all three Authentication variants count toward one token
+	assert.Contains(t, subs, "authentication")
+}


### PR DESCRIPTION
## Summary
- Adds `codebook.Compile(text string) (map[string]string, error)` that scans prose for high-frequency tokens (length > 6, frequency > 1) and returns unique short abbreviations
- Abbreviations are generated by increasing prefix length, falling back to numeric suffixes to guarantee uniqueness
- Closes #7

## Test plan
- [x] High-frequency tokens extracted and abbreviated
- [x] Short tokens (≤6 chars) excluded
- [x] Rare tokens (freq=1) excluded
- [x] Abbreviations are unique within the map
- [x] Empty input returns empty map
- [x] Case-insensitive counting (Authentication/AUTHENTICATION count as same token)

🤖 Generated with [Claude Code](https://claude.com/claude-code)